### PR TITLE
Fix imports for package modules

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:smoking_tracker_app/lib/smoking_tracker.dart'; // Ensure this path matches your project structure
+import 'package:smoking_tracker_app/smoking_tracker.dart';
 
 void main() {
   runApp(const MyApp());

--- a/test/smoking_tracker_test.dart
+++ b/test/smoking_tracker_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:smoking_tracker_app/lib/smoking_tracker.dart'; // Assuming main.dart or app.dart is in lib
+import 'package:smoking_tracker_app/smoking_tracker.dart';
 
 // Helper function to wrap the widget for testing
 Widget createTestableWidget({required Widget child}) {


### PR DESCRIPTION
## Summary
- fix incorrect package imports by removing `/lib`

## Testing
- `flutter test` *(fails: `flutter: command not found`)*